### PR TITLE
Finish 2 Years of WIP on Table State Saving/Filtering

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -209,7 +209,7 @@
     ],
     "require-jsdoc": "off",
     "semi": "error",
-    "semi-spacing": "error",
+    "semi-spacing": "off",
     "sort-imports": [
       "off",
       {
@@ -264,7 +264,7 @@
     "prefer-reflect": "off",
     "prefer-rest-params": "error",
     "prefer-spread": "error",
-    "prefer-template": "error",
+    "prefer-template": "warn",
     "require-yield": "error",
     "template-curly-spacing": "error",
     "yield-star-spacing": "error",

--- a/app/features/draft/board.component.js
+++ b/app/features/draft/board.component.js
@@ -260,8 +260,7 @@ class BoardController {
         timersSuccess,
         errorHandler
       ); // eslint-disable-line camelcase
-    } else {
-      //TODO: See if this actually required, was in place pre ES6 rewrite
+    } else if (angular.isFunction(this.deregister)) {
       this.deregister();
     }
   }

--- a/app/features/home/distinctDropdown.directive.js
+++ b/app/features/home/distinctDropdown.directive.js
@@ -1,5 +1,6 @@
-angular.module('phpdraft.home').directive('phpdDistinctDropdown', () =>
-  ({
+angular
+  .module('phpdraft.home')
+  .directive('phpdDistinctDropdown', ['tableStateService', tableStateService => ({
     restrict: 'E',
     require: '^^stTable',
     templateUrl: 'app/features/home/distinctDropdown.directive.html',
@@ -12,9 +13,17 @@ angular.module('phpdraft.home').directive('phpdDistinctDropdown', () =>
     link: (scope, element, attrs, smartTableCtrl) => {
       scope.selectedOption = null;
 
+      const initializeStateCallback = (distinct, display) => {
+        scope.selectedOption = distinct;
+        scope.selectedValue = display;
+      };
+
+      tableStateService.initializeFilterComponentFromStorage(attrs.tableStateHandle, scope.rowPropertyName, initializeStateCallback);
+
       scope.labelSelectDistinctChanged = (selectedOption, selectedValue) => {
         const query = {
           distinct: selectedOption,
+          display: selectedValue,
         };
 
         scope.selectedOption = selectedOption;
@@ -28,5 +37,5 @@ angular.module('phpdraft.home').directive('phpdDistinctDropdown', () =>
         smartTableCtrl.search(query, scope.rowPropertyName);
       };
     },
-  })
-);
+  })]
+  );

--- a/app/features/home/distinctTypeahead.directive.js
+++ b/app/features/home/distinctTypeahead.directive.js
@@ -1,11 +1,33 @@
-angular.module('phpdraft.home').directive('phpdDistinctTypeahead', ['api', 'messageService', 'limitToFilter',
-  (api, messageService, limitToFilter) =>
+/* Note: this directive is named generically, but realistically
+    genericizing the code when I did not have another use for it
+    seemed like overkill (and does again still). So there are
+    ways of genericizing this for it to truly be use-agnostic,
+    but for now this puppy is hard-coded for commissioner selection
+    only
+*/
+angular.module('phpdraft.home').directive('phpdDistinctTypeahead', [
+  'api',
+  'messageService',
+  'limitToFilter',
+  'tableStateService',
+  (api, messageService, limitToFilter, tableStateService) =>
     ({
       restrict: 'E',
       require: '^^stTable',
       templateUrl: 'app/features/home/distinctTypeahead.directive.html',
+      scope: {
+        rowPropertyName: '@',
+      },
       link: (scope, element, attrs, smartTableCtrl) => {
         scope.selectedOption = null;
+
+        const initializeStateCallback = (distinct, display) => {
+          scope.commishSelected = true;
+          scope.commishName = display;
+          scope.commishId = distinct;
+        };
+
+        tableStateService.initializeFilterComponentFromStorage(attrs.tableStateHandle, scope.rowPropertyName, initializeStateCallback);
 
         scope.searchCommisioners = searchTerm => {
           scope.commishSearchLoading = true;
@@ -23,6 +45,7 @@ angular.module('phpdraft.home').directive('phpdDistinctTypeahead', ['api', 'mess
         scope.selectCommissioner = item => {
           const query = {
             distinct: item.id,
+            display: item.name,
           };
 
           scope.commishSelected = true;
@@ -31,9 +54,7 @@ angular.module('phpdraft.home').directive('phpdDistinctTypeahead', ['api', 'mess
 
           scope.nameSearch = '';
 
-          //TODO: Branch to wipe search
-
-          smartTableCtrl.search(query, 'commish_id');
+          smartTableCtrl.search(query, scope.rowPropertyName);
         };
 
         scope.wipeCommissioner = () => {

--- a/app/features/home/draftTable.component.html
+++ b/app/features/home/draftTable.component.html
@@ -1,27 +1,24 @@
-<table st-table="$ctrl.displayedDrafts" st-set-filter="customSmartTableFilter" st-safe-src="$ctrl.drafts" class="table table-striped table-bordered">
+<table st-table="$ctrl.displayedDrafts" st-set-filter="customSmartTableFilter" st-safe-src="$ctrl.drafts"
+  phpd-persist-table-state="draftTableState" class="table table-striped table-bordered">
   <thead>
     <tr>
-      <th><input st-search="draft_name" class="form-control" placeholder="Search Leagues..." type="text"/></th>
+      <th><input st-search="draft_name" class="form-control" placeholder="Search Leagues..." type="text" /></th>
       <th>
-        <phpd-distinct-dropdown
-          list-items="$ctrl.sports"
-          row-property-name="draft_sport"
-          label-type="sport"
-          use-value-display="false">
+        <phpd-distinct-dropdown list-items="$ctrl.sports" row-property-name="draft_sport" label-type="sport"
+          use-value-display="false" table-state-handle="draftTableState">
         </phpd-distinct-dropdown>
       </th>
       <th colspan="2" class="hidden-xs hidden-sm visible-md visible-lg">
-        <phpd-distinct-typeahead></phpd-distinct-typeahead>
+        <phpd-distinct-typeahead table-state-handle="draftTableState" row-property-name="commish_id">
+        </phpd-distinct-typeahead>
       </th>
       <th class="hidden-xs visible-sm hidden-md hidden-lg">
-        <phpd-distinct-typeahead></phpd-distinct-typeahead>
+        <phpd-distinct-typeahead table-state-handle="draftTableState" row-property-name="commish_id">
+        </phpd-distinct-typeahead>
       </th>
       <th>
-        <phpd-distinct-dropdown
-          list-items="$ctrl.statuses"
-          row-property-name="draft_status"
-          label-type="status"
-          use-value-display="true">
+        <phpd-distinct-dropdown list-items="$ctrl.statuses" row-property-name="draft_status" label-type="status"
+          use-value-display="true" table-state-handle="draftTableState">
         </phpd-distinct-dropdown>
       </th>
     </tr>
@@ -38,7 +35,8 @@
         <phpd-sort-icons></phpd-sort-icons>
         Commissioner
       </th>
-      <th st-sort="$ctrl.getters.createdDate" st-sort-default="true" class="hidden-xs hidden-sm col-sm-2 sortable" class="sortable">
+      <th st-sort="$ctrl.getters.createdDate" st-sort-default="true" class="hidden-xs hidden-sm col-sm-2 sortable"
+        class="sortable">
         <phpd-sort-icons></phpd-sort-icons>
         Created
       </th>
@@ -51,33 +49,36 @@
   <tbody>
     <tr ng-repeat="draft in $ctrl.displayedDrafts">
       <td>
-        <i ng-hide="::draft.draft_visible" class="fa fa-lock" alt="Locked" title="This draft is password protected!"></i>&nbsp;
+        <i ng-hide="::draft.draft_visible" class="fa fa-lock" alt="Locked"
+          title="This draft is password protected!"></i>&nbsp;
         <strong><a href="draft/{{::draft.draft_id}}">{{::draft.draft_name}}</a></strong>
       </td>
       <td>
-        <phpd-draft-label label-type="sport" label-identifier="{{::draft.draft_sport}}" label-display="{{::draft.draft_sport}}"></phpd-draft-label>
+        <phpd-draft-label label-type="sport" label-identifier="{{::draft.draft_sport}}"
+          label-display="{{::draft.draft_sport}}"></phpd-draft-label>
       </td>
       <td class="hidden-xs">{{::draft.commish_name}}</td>
-      <td class="hidden-xs hidden-sm">{{::draft.draft_create_time | amParse: 'YYYY-MM-DD HH:mm:ss UTC' | amDateFormat:'MMMM D, YYYY'}}</td>
+      <td class="hidden-xs hidden-sm">
+        {{::draft.draft_create_time | amParse: 'YYYY-MM-DD HH:mm:ss UTC' | amDateFormat:'MMMM D, YYYY'}}</td>
       <td class="text-center">
-        <phpd-draft-label label-type="status" label-identifier="{{::draft.draft_status}}" label-display="{{::draft.display_status}}"></phpd-draft-label>
+        <phpd-draft-label label-type="status" label-identifier="{{::draft.draft_status}}"
+          label-display="{{::draft.display_status}}"></phpd-draft-label>
       </td>
     </tr>
     <tr ng-if="$ctrl.displayedDrafts.length == 0">
       <td colspan="5" class="text-center">
         <h3>No drafts here, chief.</h3>
-        <p ng-if="$ctrl.isAuthenticated"><strong>Maybe reset some search filters, or better yet... <a href="commish/draft/create">Create your own draft!</a></strong></p>
-        <p ng-if="!$ctrl.isAuthenticated"><strong>Try loosening up your search filters if you put any on, that might help.</p>
+        <p ng-if="$ctrl.isAuthenticated"><strong>Maybe reset some search filters, or better yet... <a
+              href="commish/draft/create">Create your own draft!</a></strong></p>
+        <p ng-if="!$ctrl.isAuthenticated"><strong>Try loosening up your search filters if you put any on, that might
+            help.</p>
       </td>
     </tr>
   </tbody>
   <tfoot ng-show="$ctrl.showPaging">
     <tr>
       <td colspan="6" class="text-center">
-        <div st-pagination=""
-          st-items-by-page="$ctrl.itemsByPage"
-          st-displayed-pages="7"
-          ></div>
+        <div st-pagination="" st-items-by-page="$ctrl.itemsByPage" st-displayed-pages="7"></div>
       </td>
     </tr>
   </tfoot>

--- a/app/features/home/draftTable.component.html
+++ b/app/features/home/draftTable.component.html
@@ -2,7 +2,9 @@
   phpd-persist-table-state="draftTableState" class="table table-striped table-bordered">
   <thead>
     <tr>
-      <th><input st-search="draft_name" class="form-control" placeholder="Search Leagues..." type="text" /></th>
+      <th>
+        <input st-search="{{$ctrl.draft_name}}" class="form-control" placeholder="Search Leagues..." type="text" />
+      </th>
       <th>
         <phpd-distinct-dropdown list-items="$ctrl.sports" row-property-name="draft_sport" label-type="sport"
           use-value-display="false" table-state-handle="draftTableState">
@@ -35,7 +37,7 @@
         <phpd-sort-icons></phpd-sort-icons>
         Commissioner
       </th>
-      <th st-sort="$ctrl.getters.createdDate" st-sort-default="true" class="hidden-xs hidden-sm col-sm-2 sortable"
+      <th st-sort-default="true" class="hidden-xs hidden-sm col-sm-2 sortable"
         class="sortable">
         <phpd-sort-icons></phpd-sort-icons>
         Created
@@ -70,8 +72,7 @@
         <h3>No drafts here, chief.</h3>
         <p ng-if="$ctrl.isAuthenticated"><strong>Maybe reset some search filters, or better yet... <a
               href="commish/draft/create">Create your own draft!</a></strong></p>
-        <p ng-if="!$ctrl.isAuthenticated"><strong>Try loosening up your search filters if you put any on, that might
-            help.</p>
+        <p><phpd-table-sort-reset-button table-state-handle="draftTableState"></phpd-table-sort-reset-button></p>
       </td>
     </tr>
   </tbody>

--- a/app/features/home/persistTableState.directive.js
+++ b/app/features/home/persistTableState.directive.js
@@ -1,14 +1,15 @@
 //From Smart Table docs: http://plnkr.co/edit/ekwiNt?p=preview
-angular
-  .module('phpdraft.home')
-  .directive('phpdPersistTableState', $sessionStorage => ({
+angular.module('phpdraft.home').directive('phpdPersistTableState', [
+  '$sessionStorage',
+  'subscriptionKeys',
+  ($sessionStorage, subscriptionKeys) => ({
     restrict: 'A',
     require: '^stTable',
-    link: (scope, elment, attrs, smartTableCtrl) => {
+    link: (scope, element, attrs, smartTableCtrl) => {
       const namespace = attrs.phpdPersistTableState;
 
       //Save table state every time it changes
-      scope.$watch(
+      scope.deregisterPersistTableState = scope.$watch(
         () => smartTableCtrl.tableState(),
         (newValue, oldValue) => {
           if (newValue !== oldValue) {
@@ -19,7 +20,7 @@ angular
       );
 
       //Load table state when the directive loads
-      const savedState = $sessionStorage[namespace]; //TODO: redo with ngStorage
+      const savedState = $sessionStorage[namespace];
       if (savedState) {
         const parsedSaveState = angular.fromJson(savedState);
         const tableState = smartTableCtrl.tableState();
@@ -27,5 +28,10 @@ angular
         angular.extend(tableState, parsedSaveState);
         smartTableCtrl.pipe();
       }
+
+      scope.$on(subscriptionKeys.scopeDestroy, () => {
+        scope.deregisterPersistTableState();
+      });
     },
-  }));
+  }),
+]);

--- a/app/features/home/persistTableState.directive.js
+++ b/app/features/home/persistTableState.directive.js
@@ -1,0 +1,31 @@
+//From Smart Table docs: http://plnkr.co/edit/ekwiNt?p=preview
+angular
+  .module('phpdraft.home')
+  .directive('phpdPersistTableState', $sessionStorage => ({
+    restrict: 'A',
+    require: '^stTable',
+    link: (scope, elment, attrs, smartTableCtrl) => {
+      const namespace = attrs.phpdPersistTableState;
+
+      //Save table state every time it changes
+      scope.$watch(
+        () => smartTableCtrl.tableState(),
+        (newValue, oldValue) => {
+          if (newValue !== oldValue) {
+            $sessionStorage[namespace] = newValue;
+          }
+        },
+        true
+      );
+
+      //Load table state when the directive loads
+      const savedState = $sessionStorage[namespace]; //TODO: redo with ngStorage
+      if (savedState) {
+        const parsedSaveState = angular.fromJson(savedState);
+        const tableState = smartTableCtrl.tableState();
+
+        angular.extend(tableState, parsedSaveState);
+        smartTableCtrl.pipe();
+      }
+    },
+  }));

--- a/app/features/home/tableSortResetButton.directive.html
+++ b/app/features/home/tableSortResetButton.directive.html
@@ -1,0 +1,3 @@
+<button ng-if="!disableButton" type="button" ng-click="wipeFilters()">
+    Reset All Filters
+</button>

--- a/app/features/home/tableSortResetButton.directive.js
+++ b/app/features/home/tableSortResetButton.directive.js
@@ -1,0 +1,37 @@
+angular
+  .module('phpdraft.home')
+  .directive('phpdTableSortResetButton', ['tableStateService', tableStateService => ({
+    restrict: 'E',
+    require: '^stTable',
+    templateUrl: 'app/features/home/tableSortResetButton.directive.html',
+    scope: {
+      tableStateHandle: '@',
+    },
+    link: (scope, element, attrs, smartTableCtrl) => {
+      scope.deregisterTableStateChangeWatcher = scope.$watch(
+        () => smartTableCtrl.tableState(),
+        (newValue, oldValue) => {
+          if (newValue !== oldValue) {
+            const newDisableButton = !tableStateService.tableStateExists(scope.tableStateHandle);
+            if (newDisableButton !== scope.disableButton) {
+              scope.disableButton = newDisableButton;
+            }
+          }
+        },
+        true
+      );
+
+      scope.disableButton = !tableStateService.tableStateExists(scope.tableStateHandle);
+      scope.wipeFilters = () => {
+        if (scope.disableButton) return;
+
+        let tableState = smartTableCtrl.tableState();//eslint-disable-line
+        tableState = tableStateService.wipeStateFilterObject(tableState);
+
+        smartTableCtrl.pipe();
+        //Known bug: the st-search input box still displays the value, even
+        //though SmartTable no longer filters by it. Gah.
+      };
+    },
+  })]
+  );

--- a/app/features/home/tableState.service.js
+++ b/app/features/home/tableState.service.js
@@ -15,26 +15,79 @@ class TableStateService {
     if (!initCallback ||
       !angular.isFunction(initCallback)) return;
 
-    const savedState = this.$sessionStorage[tableStateHandle];
+    if (!this.rowPropertyExists(tableStateHandle, rowPropertyName)) return;
 
-    //If no saved state object from storage exists, stop here
-    if (!savedState) return;
-
-    const parsedSaveState = angular.fromJson(savedState);
-
-    //If any of these properties don't exist, we can also stop here
-    if (!parsedSaveState.search ||
-      !parsedSaveState.search.predicateObject ||
-      !parsedSaveState.search.predicateObject[rowPropertyName] ||
-      !parsedSaveState.search.predicateObject[rowPropertyName].distinct) {
-      return;
-    }
+    const parsedSaveState = this.parseTableState(tableStateHandle);
 
     const distinct = parsedSaveState.search.predicateObject[rowPropertyName].distinct;
     const display = parsedSaveState.search.predicateObject[rowPropertyName].display;
 
     //Call the callback with the stored data
     initCallback(distinct, display);
+  }
+
+  /*
+    Determine if table state exists (filters are applied)
+  */
+  tableStateExists(tableStateHandle) {
+    const savedState = this.$sessionStorage[tableStateHandle];
+    console.log(`Hey, asked about existing table state for ${tableStateHandle}`);
+
+    if (!savedState) {
+      return false;
+    }
+
+    const parsedSaveState = angular.fromJson(savedState);
+    const hasSearch = parsedSaveState.search && Boolean(parsedSaveState.search.predicateObject);
+
+    if (!hasSearch) {
+      return false;
+    }
+
+    if (hasSearch) {
+      let hasOneSubkey = false;
+
+      //Verify that predicate has at least 1 object with sub-keys
+      Object.keys(parsedSaveState.search.predicateObject).forEach(key => {
+        const predicate = parsedSaveState.search.predicateObject[key];
+        if (Object.keys(predicate).length) hasOneSubkey = true;
+      });
+
+      return hasOneSubkey;
+    }
+
+    return true;
+  }
+
+  parseTableState(tableStateHandle) {
+    return angular.fromJson(this.$sessionStorage[tableStateHandle]);
+  }
+
+  /*
+    Determine if a specific property exists in table state
+    (also calls tableStateExists)
+  */
+  rowPropertyExists(tableStateHandle, rowPropertyName) {
+    if (this.tableStateExists(tableStateHandle) === false) return false;
+
+    const parsedSaveState = this.parseTableState(tableStateHandle);
+
+    const propertyExists = parsedSaveState.search &&
+      parsedSaveState.search.predicateObject &&
+      parsedSaveState.search.predicateObject[rowPropertyName] &&
+      parsedSaveState.search.predicateObject[rowPropertyName].distinct;
+
+    return Boolean(propertyExists);
+  }
+
+  /*
+    Given the predicate object, ensure all children
+    have empty distinct properties
+  */
+  wipeStateFilterObject(tableState) {
+    tableState.search = {};
+
+    return tableState;
   }
 }
 

--- a/app/features/home/tableState.service.js
+++ b/app/features/home/tableState.service.js
@@ -1,0 +1,45 @@
+class TableStateService {
+  constructor($sessionStorage) {
+    this.$sessionStorage = $sessionStorage;
+  }
+
+  /*
+    Encapsulated logic that initializes a single column component upon page render
+    from session storage, and calls the provided callback if there is valid savestate
+  */
+  initializeFilterComponentFromStorage(tableStateHandle, rowPropertyName, initCallback) {
+    //If we havent been given a tableStateHandle just stop here
+    if (!tableStateHandle) return;
+
+    //If we havent been given a callback just stop here
+    if (!initCallback ||
+      !angular.isFunction(initCallback)) return;
+
+    const savedState = this.$sessionStorage[tableStateHandle];
+
+    //If no saved state object from storage exists, stop here
+    if (!savedState) return;
+
+    const parsedSaveState = angular.fromJson(savedState);
+
+    //If any of these properties don't exist, we can also stop here
+    if (!parsedSaveState.search ||
+      !parsedSaveState.search.predicateObject ||
+      !parsedSaveState.search.predicateObject[rowPropertyName] ||
+      !parsedSaveState.search.predicateObject[rowPropertyName].distinct) {
+      return;
+    }
+
+    const distinct = parsedSaveState.search.predicateObject[rowPropertyName].distinct;
+    const display = parsedSaveState.search.predicateObject[rowPropertyName].display;
+
+    //Call the callback with the stored data
+    initCallback(distinct, display);
+  }
+}
+
+TableStateService.$inject = [
+  '$sessionStorage',
+];
+
+angular.module('phpdraft.home').service('tableStateService', TableStateService);

--- a/app/features/navigation/footerBar.component.html
+++ b/app/features/navigation/footerBar.component.html
@@ -2,7 +2,7 @@
   <div class="container-fluid">
     <div class="col-xs-4">
       <p class="navbar-text">
-        <a href="https://github.com/mattheworres/phpdraft">HootDraft v2.3.3</a>
+        <a href="https://github.com/mattheworres/phpdraft">HootDraft v2.4.0</a>
       </p>
     </div>
     <div class="col-xs-4 navbar-header-middle">

--- a/deploy/config.js.ci
+++ b/deploy/config.js.ci
@@ -1,5 +1,5 @@
 (function(angular, undefined) {
-  angular.module("config", [])
+  angular.module("phpdraft.env", [])
 
 .constant("ENV", {
   "apiEndpoint": "{phpdraft.apiBaseUrl}",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "angular-toggle-switch": "~1.3.0",
     "angular-ui-bootstrap": "~2.5.6",
     "angular-validation-match": "~1.7.1",
-    "bootstrap": "3.3.7",
+    "bootstrap": "3.4.1",
     "flipclock": "0.7.7",
     "font-awesome": "~4.7.0",
     "jquery": "~3.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1510,10 +1510,10 @@ bn.js@^5.1.1:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
   integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
 
-bootstrap@3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
-  integrity sha1-WjiTlFSfIzMIdaOxUGVldPip63E=
+bootstrap@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
+  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
 
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
A big annoyance of mine, is always coming back to seeing the oldest drafts on the homepage (and thinking others would find it helpful to not always see the same old drafts first). So now: Hoot Draft will remember how you filtered the table, and act accordingly.

Known bug: I wasn't able to get the league name st-search value to disappear, but that's minor enough it's better that I just get this WIP off of my plate finally. I seriously started this change in 2019 and just now got back to it! Yikes.

Hoping to get some work in on a few other "legit" features for NFL 2021 this August 🤞 